### PR TITLE
Update deprecated functions to currently supported ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 All changes are in the `main` branch (`master` remains unchanged).
 
-### v4.2.1
+### v4.3.0
++   Update minor version due to using non-deprecated functions which may break previously supported OTP versions
 +   Update license copyright
 +   Remove overly restrictive semantic versioning of deps for hex in elixir
 +   Modify APIs to use non-deprecated functions for recent versions of erlang

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,7 @@
 # Contributors
 
 Contributions are welcome but they do require that you agree to Dropbox's _Contributor License Agreement_ found [here](https://opensource.dropbox.com/cla/).
+
+Fixes that enable compatibility with different IdP implementations are welcome if and only if they do not come at the expense of compatibility with already supported IdPs. `esaml` prefers to follow as closely to the SAML standards as possible.
+
+Bugs/issues opened without patches are also welcome, but might take a lot longer to be looked at. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 An implementation of the Security Assertion Markup Language (SAML) in Erlang. So far this supports enough of the standard to act as a Service Provider (SP) to perform authentication with SAML. It has been tested extensively against the SimpleSAMLphp IdP and can be used in production.
 
+Please read [this](CONTRIBUTORS.md) in order to make contributions.
+
 ### Supported protocols
 
 The SAML standard refers to a flow of request/responses that make up one concrete action as a "protocol". Currently all of the basic Single-Sign-On and Single-Logout protocols are supported. There is no support at present for the optional Artifact Resolution, NameID Management, or NameID Mapping protocols.
@@ -51,9 +53,3 @@ You can also tap straight into lower-level APIs in `esaml` if `esaml_cowboy` doe
 This is particularly useful if you want to implement SOAP endpoints using SAML.
 
 > The Elixir library `Samly` is one such implementation. It dose not use `esaml_cowboy`. Instead it relies on the lower-level APIs and uses Elixir `Plug` and `Cowboy` directly for endpoints/routing.
-
-### Contributions
-
-Pull requests are always welcome for bug fixes and improvements. Fixes that enable compatibility with different IdP implementations are usually welcome, but please ensure they do not come at the expense of compatibility with another IdP. `esaml` prefers to follow as closely to the SAML standards as possible.
-
-Bugs/issues opened without patches are also welcome, but might take a lot longer to be looked at. ;)

--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 {ct_verbose, true}.
 
 {deps, [
-    {cowboy, "~> 2.6"}
+    {cowboy, "< 3.0.0"}
 ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/src/esaml.app.src
+++ b/src/esaml.app.src
@@ -1,7 +1,7 @@
 {application, esaml,
     [
         {description, "SAML Server Provider library for erlang"},
-        {vsn, "4.2.1"},
+        {vsn, "4.3.0"},
         {modules, []},
         {registered, []},
         {applications, [

--- a/src/esaml.app.src
+++ b/src/esaml.app.src
@@ -1,7 +1,7 @@
 {application, esaml,
     [
         {description, "SAML Server Provider library for erlang"},
-        {vsn, "4.2.0"},
+        {vsn, "4.2.1"},
         {modules, []},
         {registered, []},
         {applications, [
@@ -14,12 +14,11 @@
             cowboy,
             ranch
         ]},
-        {licenses, ["https://github.com/arekinath/esaml/blob/master/LICENSE"]},
+        {licenses, ["https://github.com/dropbox/esaml/blob/master/LICENSE"]},
         {links, [
-            {"Github", "https://github.com/handnot2/esaml"},
-            {"Original Repo", "https://github.com/arekinath/esaml"},
-            {"K2InformaticsGmbH", "https://github.com/K2InformaticsGmbH/esaml"},
-            {"VendorHawk", "https://github.com/VendorHawk/esaml"}
+            {"Github", "https://github.com/dropbox/esaml"},
+            {"Forked From", "https://github.com/handnot2/esaml"},
+            {"Original Repo", "https://github.com/arekinath/esaml"}
         ]},
         {env, [
             {org_name, "SAML Service Provider"},

--- a/src/esaml_binding.erl
+++ b/src/esaml_binding.erl
@@ -57,14 +57,14 @@ decode_response(_, SAMLResponse) ->
 encode_http_redirect(IdpTarget, SignedXml, Username, RelayState) ->
   Type = xml_payload_type(SignedXml),
   Req = lists:flatten(xmerl:export([SignedXml], xmerl_xml)),
-  Param = http_uri:encode(base64:encode_to_string(zlib:zip(Req))),
-  RelayStateEsc = http_uri:encode(binary_to_list(RelayState)),
+  Param = uri_string:normalize(base64:encode_to_string(zlib:zip(Req))),
+  RelayStateEsc = uri_string:normalize(binary_to_list(RelayState)),
   FirstParamDelimiter = case lists:member($?, IdpTarget) of true -> "&"; false -> "?" end,
   Username_Part = redirect_username_part(Username),
   iolist_to_binary([IdpTarget, FirstParamDelimiter, "SAMLEncoding=", ?deflate, "&", Type, "=", Param, "&RelayState=", RelayStateEsc | Username_Part]).
 
 redirect_username_part(Username) when is_binary(Username), size(Username) > 0 ->
-  ["&username=", http_uri:encode(binary_to_list(Username))];
+  ["&username=", uri_string:normalize(binary_to_list(Username))];
 redirect_username_part(_Other) -> [].
 
 %% @doc Encode a SAMLRequest (or SAMLResponse) as an HTTP-POST binding

--- a/src/esaml_binding.erl
+++ b/src/esaml_binding.erl
@@ -57,7 +57,8 @@ decode_response(_, SAMLResponse) ->
 encode_http_redirect(IdpTarget, SignedXml, Username, RelayState) ->
   Type = xml_payload_type(SignedXml),
   Req = lists:flatten(xmerl:export([SignedXml], xmerl_xml)),
-  Param = uri_string:normalize(base64:encode_to_string(zlib:zip(Req))),
+  % TODO: unsure how to manage Param since no uri_string function can perform the required percent-encoding
+  Param = http_uri:encode(base64:encode_to_string(zlib:zip(Req))),
   RelayStateEsc = uri_string:normalize(binary_to_list(RelayState)),
   FirstParamDelimiter = case lists:member($?, IdpTarget) of true -> "&"; false -> "?" end,
   Username_Part = redirect_username_part(Username),

--- a/src/esaml_sp.erl
+++ b/src/esaml_sp.erl
@@ -334,18 +334,18 @@ block_decrypt("http://www.w3.org/2009/xmlenc11#aes128-gcm", SymmetricKey, Cipher
     %% IV: 12 bytes and Tag data: 16 bytes
     EncryptedDataSize = byte_size(CipherValue) - 12 - 16,
     <<IV:12/binary, EncryptedData:EncryptedDataSize/binary, Tag:16/binary>> = CipherValue,
-    DecryptedData = crypto:block_decrypt(aes_gcm, SymmetricKey, IV, {<<>>, EncryptedData, Tag}),
+    DecryptedData = crypto:crypto_one_time_aead(aes_128_gcm, SymmetricKey, IV, EncryptedData, <<>>, Tag, false),
     binary_to_list(DecryptedData);
 
 block_decrypt("http://www.w3.org/2001/04/xmlenc#aes128-cbc", SymmetricKey, CipherValue) ->
     <<IV:16/binary, EncryptedData/binary>> = CipherValue,
-    DecryptedData = crypto:block_decrypt(aes_cbc128, SymmetricKey, IV, EncryptedData),
+    DecryptedData = crypto:crypto_one_time(aes_128_cbc, SymmetricKey, IV, EncryptedData, false),
     IsPadding = fun(X) -> X < 16 end,
     lists:reverse(lists:dropwhile(IsPadding, lists:reverse(binary_to_list(DecryptedData))));
 
 block_decrypt("http://www.w3.org/2001/04/xmlenc#aes256-cbc", SymmetricKey, CipherValue) ->
     <<IV:16/binary, EncryptedData/binary>> = CipherValue,
-    DecryptedData = crypto:block_decrypt(aes_cbc256, SymmetricKey, IV, EncryptedData),
+    DecryptedData = crypto:crypto_one_time(aes_256_cbc, SymmetricKey, IV, EncryptedData, false),
     IsPadding = fun(X) -> X < 16 end,
     lists:reverse(lists:dropwhile(IsPadding, lists:reverse(binary_to_list(DecryptedData)))).
 


### PR DESCRIPTION
Even before this PR there was a breaking test which needs to be fixed.

I have manually tested this against an Okta integration and it seems to work. I am new to `erlang` coming from `elixir` so I am hoping to get feedback and have some better support of this library.