### PR TITLE
Mapping of common attribute now keeps the initial fields

### DIFF
--- a/src/esaml.erl
+++ b/src/esaml.erl
@@ -293,11 +293,12 @@ decode_assertion_attributes(Xml) ->
             [Name] ->
                 case xmerl_xpath:string("saml:AttributeValue/text()", AttrElem, [{namespace, Ns}]) of
                     [#xmlText{value = Value}] ->
-                        [{common_attrib_map(Name), Value} | In];
+                        [{common_attrib_map(Name), Value} | [{Name, Value} | In]];
                     List ->
                         if (length(List) > 0) ->
                             Value = [X#xmlText.value || X <- List, element(1, X) =:= xmlText],
-                            [{common_attrib_map(Name), Value} | In];
+                            [{common_attrib_map(Name), Value} | [{Name, Value} | In]];
+
                         true ->
                             In
                         end


### PR DESCRIPTION
The mapping done by esaml works well but does not add the initial fields to the result. This PR solves the matter by keeping all the data sent by the IDPs. This helped us to provide helpful logs for debugging and clearly improve maintainability.

From our test, this has no impact on the current implementation. While I don't expect a direct merge, I hope to gather some of your feedbacks/ideas.

Before this change:
```elixir
%{      
  givenName: 'Student',
  mail: 'student1@xxx.nl',
  surName: 'One',
  uid: 'student1',
  "urn:mace:dir:attribute-def:givenName": 'Student',
  "urn:mace:dir:attribute-def:mail": 'student1@xxx.nl',
  "urn:mace:dir:attribute-def:sn": 'One',
  "urn:mace:dir:attribute-def:uid": 'student1', 
  "urn:oid:1.3.6.1.4.1.25178.1.2.9": 'xxx.nl'
}
```

After this change:
```elixir
%{      
  :givenName => 'Student',
  :mail => 'student1@xxx.nl',
  :surName => 'One',
  :uid => 'student1',
  :"urn:mace:dir:attribute-def:givenName" => 'Student',
  :"urn:mace:dir:attribute-def:mail" => 'student1@xxx.nl',
  :"urn:mace:dir:attribute-def:sn" => 'One',
  :"urn:mace:dir:attribute-def:uid" => 'student1',
  :"urn:oid:1.3.6.1.4.1.25178.1.2.9" => 'xxx.nl',
  'urn:mace:dir:attribute-def:givenName' => 'Student',
  'urn:mace:dir:attribute-def:mail' => 'student1@xxx.nl',
  'urn:mace:dir:attribute-def:sn' => 'One',
  'urn:mace:dir:attribute-def:uid' => 'student1',
  'urn:mace:terena.org:attribute-def:schacHomeOrganization' => 'xxx.nl',
  'urn:oid:0.9.2342.19200300.100.1.1' => 'student1',
  'urn:oid:0.9.2342.19200300.100.1.3' => 'student1@xxx.nl',
  'urn:oid:1.3.6.1.4.1.25178.1.2.9' => 'xxx.nl',
  'urn:oid:2.5.4.4' => 'One',
  'urn:oid:2.5.4.42' => 'Student'
}
```