### PR TITLE
Remove use of http_uri:encode

### DIFF
--- a/src/esaml_binding.erl
+++ b/src/esaml_binding.erl
@@ -57,15 +57,20 @@ decode_response(_, SAMLResponse) ->
 encode_http_redirect(IdpTarget, SignedXml, Username, RelayState) ->
   Type = xml_payload_type(SignedXml),
   Req = lists:flatten(xmerl:export([SignedXml], xmerl_xml)),
-  % TODO: unsure how to manage Param since no uri_string function can perform the required percent-encoding
-  Param = http_uri:encode(base64:encode_to_string(zlib:zip(Req))),
-  RelayStateEsc = uri_string:normalize(binary_to_list(RelayState)),
+
+  QueryList = [
+               {"SAMLEncoding", ?deflate},
+               {Type, uri_string:quote(base64:encode_to_string(zlib:zip(Req)))},
+               {"RelayState", uri_string:normalize(binary_to_list(RelayState))}
+              ],
+  QueryParamStr = uri_string:compose_query(QueryList),
   FirstParamDelimiter = case lists:member($?, IdpTarget) of true -> "&"; false -> "?" end,
   Username_Part = redirect_username_part(Username),
-  iolist_to_binary([IdpTarget, FirstParamDelimiter, "SAMLEncoding=", ?deflate, "&", Type, "=", Param, "&RelayState=", RelayStateEsc | Username_Part]).
+
+  iolist_to_binary([IdpTarget, FirstParamDelimiter, QueryParamStr | Username_Part]).
 
 redirect_username_part(Username) when is_binary(Username), size(Username) > 0 ->
-  ["&username=", uri_string:normalize(binary_to_list(Username))];
+  ["&", uri_string:compose_query([{"username", uri_string:normalize(binary_to_list(Username))}])];
 redirect_username_part(_Other) -> [].
 
 %% @doc Encode a SAMLRequest (or SAMLResponse) as an HTTP-POST binding


### PR DESCRIPTION
## Overview

This removes the use of the deprecated `http_uri` module and replaces it with the recommend `uri_string` module.

`uri_string` has been recommended since OTP 21, and `http_uri` will be removed completely in OTP 26.

### Changes

This uses `uri_string:compose_query/1` to build up the query parameters (instead of manually concatenating a binary). It relies on the the function's behavior that will put keys and values through `uri_string:quote()` (so we must be sure we don't double-encode).

In testing several XML payloads run through `base64:encode_to_string(zlib:zip(Req))` and then comparing the results of both `http_uri:encode()` vs. `uri_string:quote()`, my results consistently matched. If there is a known difference between the output of the two functions?

### Unknowns

* is `uri_string:normalize()` on the `RelayState` also doing percent encoding?
* is there a cleaner way to *maybe* add the `"username"` parameter to the `QueryList`?