### PR TITLE
fix: get rid of extra uri encoding

### DIFF
--- a/src/esaml_binding.erl
+++ b/src/esaml_binding.erl
@@ -60,7 +60,7 @@ encode_http_redirect(IdpTarget, SignedXml, Username, RelayState) ->
 
   QueryList = [
                {"SAMLEncoding", ?deflate},
-               {Type, uri_string:quote(base64:encode_to_string(zlib:zip(Req)))},
+               {Type, base64:encode_to_string(zlib:zip(Req))},
                {"RelayState", uri_string:normalize(binary_to_list(RelayState))}
               ],
   QueryParamStr = uri_string:compose_query(QueryList),


### PR DESCRIPTION
Esaml double url encodes the type parameter which causes IdP's to error during the initial redirect step. 

I have provided a more detailed write up in https://github.com/dropbox/samly/pull/12, that includes ways of reproducing this bug.